### PR TITLE
fix: fix input when calling get_version

### DIFF
--- a/cli/cli/syntho_cli.py
+++ b/cli/cli/syntho_cli.py
@@ -303,7 +303,7 @@ def k8s_deployment(
         trusted_registry_image_pull_secret,
         skip_configuration,
         use_trusted_registry,
-        get_version("cli"),
+        get_version("syntho-cli"),
     )
 
     if result.succeeded:
@@ -531,7 +531,7 @@ def dc_deployment(
         skip_configuration,
         use_trusted_registry,
         use_offline_registry,
-        get_version("cli"),
+        get_version("syntho-cli"),
     )
 
     if result.succeeded:


### PR DESCRIPTION
that behavior changed after this [commit](https://github.com/syntho-ai/deployment-tools/commit/dfe78b3a6e6393c92f108386deeeefba4e83ff71)