### PR TITLE
fix: update backend healthcheck endpoint

### DIFF
--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -101,7 +101,7 @@ spec:
               memory: "2Gi"
           readinessProbe:
             httpGet:
-              path: /api/docs/
+              path: /api/v1/live/
               port: 8000
               httpHeaders:
               - name: Host
@@ -113,7 +113,7 @@ spec:
             successThreshold: 1
           livenessProbe:
             httpGet:
-              path: /api/docs/
+              path: /api/v1/live/
               port: 8000
               httpHeaders:
               - name: Host


### PR DESCRIPTION
Small change to update the backend healthcheck endpoint to `/api/v1/live`