### PR TITLE
Enable usage of loadbalancer for frontend in Helm

### DIFF
--- a/helm/syntho-ui/templates/NOTES.txt
+++ b/helm/syntho-ui/templates/NOTES.txt
@@ -5,16 +5,16 @@
   http{{ if $.Values.frontend.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "syntho-core.fullname" . }})
+{{- else if contains "NodePort" .Values.frontend.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services frontend)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.frontend.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "syntho-core.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "syntho-core.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w frontend'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} frontend --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.frontend.service.port }}
+{{- else if contains "ClusterIP" .Values.frontend.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "syntho-core.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: WORKERS
               value: {{quote .Values.backend.workers }}
             - name: EXTRA_ALLOWED_HOSTS
-              value: "{{ .Values.frontend_url }} {{ .Values.backend.name }}.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "{{ trimAll ":3000" .Values.frontend_url }} {{ .Values.backend.name }}.{{ .Release.Namespace }}.svc.cluster.local"
           {{- if or $.Values.backend.env $.Values.backend.envSecrets }}
             {{- range $key, $value := $.Values.backend.env }}
             - name: {{ $key }}

--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -71,6 +71,10 @@ spec:
               value: {{quote .Values.backend.workers }}
             - name: EXTRA_ALLOWED_HOSTS
               value: "{{ trimAll ":3000" .Values.frontend_url }} {{ .Values.backend.name }}.{{ .Release.Namespace }}.svc.cluster.local"
+            {{- if eq .Values.frontend_protocol "http"}}
+            - name: SECURE_COOKIES
+              value: "False"
+            {{- end }}
           {{- if or $.Values.backend.env $.Values.backend.envSecrets }}
             {{- range $key, $value := $.Values.backend.env }}
             - name: {{ $key }}

--- a/helm/syntho-ui/templates/frontend/frontend-service.yaml
+++ b/helm/syntho-ui/templates/frontend/frontend-service.yaml
@@ -10,6 +10,7 @@ spec:
     - name: frontend-port
       port: {{ .Values.frontend.service.port }}
       targetPort: {{ .Values.frontend.service.port }}
+  type: {{ .Values.frontend.service.type | default "ClusterIP" }}
   selector:
     app: frontend
 status:


### PR DESCRIPTION
- Enable usage of Loadbalancer directly for frontend 

This however currently requires manually adjusting `frontend_url` in Helm chart after deploying, since the loadbalancer URL is not known at the time of deployment often.