### PR TITLE
Syntho Application Release actions workflow

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -4,8 +4,6 @@ version = "1.13.0"
 tag_format = "$version"
 version_files = [
     "cli/pyproject.toml:version",
-    "helm/ray/Chart.yaml:version",
-    "helm/syntho-ui/Chart.yaml:version",
     "pyproject.toml:version",
     "dynamic-configuration/pyproject.toml:version"
 ]

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,42 +1,42 @@
-name: Bump version
+# name: Bump version
 
-on:
-  push:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
 
-jobs:
-  bump-version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
-    runs-on: ubuntu-latest
-    name: "Bump version and create changelog with commitizen"
-    permissions:
-      contents: write
-    steps:
-      - name: Check out
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
-      - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
-        with:
-          changelog_increment_filename: changelog.md
-          github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
-      - name: Zip docker-compose and Helm charts
-        run: |
-          tar -czf docker-compose.tar.gz docker-compose
-          tar -czf ray-helm-chart.tar.gz helm/ray
-          tar -czf syntho-ui-helm-chart.tar.gz helm/syntho-ui
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: "changelog.md"
-          tag_name: ${{ env.REVISION }}
-          files: |
-            changelog.md
-            docker-compose.tar.gz
-            ray-helm-chart.tar.gz
-            syntho-ui-helm-chart.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# jobs:
+#   bump-version:
+#     if: "!startsWith(github.event.head_commit.message, 'bump:')"
+#     runs-on: ubuntu-latest
+#     name: "Bump version and create changelog with commitizen"
+#     permissions:
+#       contents: write
+#     steps:
+#       - name: Check out
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
+#           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+#       - name: Create bump and changelog
+#         uses: commitizen-tools/commitizen-action@master
+#         with:
+#           changelog_increment_filename: changelog.md
+#           github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+#       - name: Zip docker-compose and Helm charts
+#         run: |
+#           tar -czf docker-compose.tar.gz docker-compose
+#           tar -czf ray-helm-chart.tar.gz helm/ray
+#           tar -czf syntho-ui-helm-chart.tar.gz helm/syntho-ui
+#       - name: Release
+#         uses: softprops/action-gh-release@v1
+#         with:
+#           body_path: "changelog.md"
+#           tag_name: ${{ env.REVISION }}
+#           files: |
+#             changelog.md
+#             docker-compose.tar.gz
+#             ray-helm-chart.tar.gz
+#             syntho-ui-helm-chart.tar.gz
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,42 +1,34 @@
-# name: Bump version
+name: Bump version
 
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
-# jobs:
-#   bump-version:
-#     if: "!startsWith(github.event.head_commit.message, 'bump:')"
-#     runs-on: ubuntu-latest
-#     name: "Bump version and create changelog with commitizen"
-#     permissions:
-#       contents: write
-#     steps:
-#       - name: Check out
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
-#       - name: Create bump and changelog
-#         uses: commitizen-tools/commitizen-action@master
-#         with:
-#           changelog_increment_filename: changelog.md
-#           github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
-#       - name: Zip docker-compose and Helm charts
-#         run: |
-#           tar -czf docker-compose.tar.gz docker-compose
-#           tar -czf ray-helm-chart.tar.gz helm/ray
-#           tar -czf syntho-ui-helm-chart.tar.gz helm/syntho-ui
-#       - name: Release
-#         uses: softprops/action-gh-release@v1
-#         with:
-#           body_path: "changelog.md"
-#           tag_name: ${{ env.REVISION }}
-#           files: |
-#             changelog.md
-#             docker-compose.tar.gz
-#             ray-helm-chart.tar.gz
-#             syntho-ui-helm-chart.tar.gz
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  bump-version:
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: "Bump version and create changelog with commitizen"
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          changelog_increment_filename: changelog.md
+          github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "changelog.md"
+          tag_name: syntho-cli-${{ env.REVISION }}
+          files: |
+            changelog.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/syntho-release-workflow.yaml
+++ b/.github/workflows/syntho-release-workflow.yaml
@@ -1,0 +1,36 @@
+name: Create Syntho Application Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      syntho_version:
+        description: 'Syntho Application Version'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes for this version'
+        required: false
+        type: string
+
+jobs:
+  release-cli:
+    runs-on: ubuntu-latest
+    name: "Create Draft Release for Syntho Application"
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Zip docker-compose and Helm charts
+        run: |
+          tar -czf syntho-${{ inputs.syntho_version }}.tar.gz docker-compose helm dynamic-configuration/dc_questions.yaml dynamic-configuration/k8s_questions.yaml
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          body: "${{ inputs.release_notes }}"
+          tag_name: ${{ inputs.syntho_version }}
+          files: |
+            syntho-${{ inputs.syntho_version }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
An additional manually triggered pipeline that will create a draft release with the version that has been supplied, together with release notes that have been supplied (or can be created manually after changing the draft and publishing it). 

The goal of this pipeline is to have a pipeline that can be triggered from another process (pipeline, API, whatever) that takes a few inputs like the version number of the Syntho Application, and the release notes for that version. This will then create a draft release, which can later be published and be used in the Syntho CLI to list versions and get the right manifest (helm charts, question files) to deploy the Syntho Application.