### PR TITLE
Add pipeline for Docker Compose linting

### DIFF
--- a/.github/workflows/lint-dc.yaml
+++ b/.github/workflows/lint-dc.yaml
@@ -5,6 +5,10 @@ on: pull_request
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./docker-compose
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint-dc.yaml
+++ b/.github/workflows/lint-dc.yaml
@@ -1,0 +1,23 @@
+name: Linting for Docker Compose
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check differences between example.env and .env.tpl
+        run: |
+         export DIFF_LINES=$(
+            ENV1=.env.tpl                                                                                                                                                                               ENV1=.env.tpl
+            ENV2=example.env
+            diff --suppress-common-lines -y \
+              <(grep -v -E '^#|^$' ${ENV1} | cut -d= -f1 | sort) \
+              <(grep -v -E '^#|^$' ${ENV2} | cut -d= -f1 | sort) | wc -l
+          )
+          echo "Number of differences: $DIFF_LINES"
+          exit $DIFF_LINES


### PR DESCRIPTION
- Add CI/CD pipeline for linting for Docker compose, currently only check if there are differences between `example.env` and `.tpl.env`