### PR TITLE
fix: handles space in in var, and escapes double quotas

### DIFF
--- a/cli/cli/dynamic_configuration/core.py
+++ b/cli/cli/dynamic_configuration/core.py
@@ -244,4 +244,7 @@ def dump_envs(all_envs, deployment_dir):
         env_file_path = f"{deployment_dir}/{scope}"
         with open(env_file_path, "w") as file:
             for key, value in scope_envs_as_mapping.items():
-                file.write(f"{key}={value}\n")
+                # Manually escape double quotes within the value
+                escaped_value = value.replace('"', '\\"')
+                # Wrap the value in double quotes
+                file.write(f'{key}="{escaped_value}"\n')


### PR DESCRIPTION
`.post.deployment.ops.env` has this 
```
INGRESS_ANNOTATION=cert-manager.io/cluster-issuer: "letsencrypt-production"
```
and this PR is fixing it.
```
INGRESS_ANNOTATION="cert-manager.io/cluster-issuer: \"letsencrypt-production\""
```