### PR TITLE
chore: adjusts the default values when using --skip-configuration vs when the questions are asked

### DIFF
--- a/dynamic-configuration/src/dc_questions.yaml
+++ b/dynamic-configuration/src/dc_questions.yaml
@@ -116,9 +116,9 @@ envs_configuration:
   - scope: .resources.env
     envs:
       - name: RAY_CPUS
-        default: "6"
+        default: "1"
       - name: RAY_MEMORY
-        default: "32G"
+        default: "4G"
   - scope: .auth.env
     envs:
       - name: UI_ADMIN_LOGIN_EMAIL

--- a/dynamic-configuration/src/k8s_questions.yaml
+++ b/dynamic-configuration/src/k8s_questions.yaml
@@ -152,9 +152,9 @@ questions:
               args: ["ReadWriteOnce"]
 
   - id: use_ingress_controller
-    question: "Do you want to use your own ingress controller for reaching the Syntho's UI? (Y/n) (default: n):"
+    question: "Do you want to use your own ingress controller for reaching the Syntho's UI? (Y/n) (default: y):"
     var: USE_INGRESS_CONTROLLER
-    default: "n"
+    default: "y"
     validation:
       - func: regex
         args: ["^[yYnN]$", "$USE_INGRESS_CONTROLLER"]
@@ -524,13 +524,13 @@ envs_configuration:
   - scope: .resources.env
     envs:
       - name: RAY_HEAD_CPU_REQUESTS
-        default: "6000m"
+        default: "500m"
       - name: RAY_HEAD_CPU_LIMIT
-        default: "6000m"
+        default: "1000m"
       - name: RAY_HEAD_MEMORY_REQUESTS
-        default: "32G"
+        default: "2G"
       - name: RAY_HEAD_MEMORY_LIMIT
-        default: "32G"
+        default: "4G"
   - scope: .auth.env
     envs:
       - name: UI_ADMIN_LOGIN_EMAIL
@@ -542,7 +542,7 @@ envs_configuration:
       - name: DEPLOY_LOCAL_VOLUME_PROVISIONER
         default: "y"
       - name: DEPLOY_INGRESS_CONTROLLER
-        default: "n"
+        default: "y"
       - name: CREATE_SECRET_FOR_SSL
         default: "n"
       - name: SSL_CERT


### PR DESCRIPTION
Considering that --skip-configuration is meant to be for only development experiments, I've adjusted those default values accordingly. 

However when the questions are asked, then the default value per question if skipped remained same considering that it is going be for a production cluster.

Later, we will be implementing a mechanism to provide a declarative configuration explicitly and perhaps disable --skip-configuration functionality.