### PR TITLE
Use manual secret name if set and add license key to secrets

### DIFF
--- a/.github/workflows/lint-helm-charts.yaml
+++ b/.github/workflows/lint-helm-charts.yaml
@@ -11,7 +11,7 @@ jobs:
           - dir: 'helm/syntho-ui'
             dyff_args: '--exclude "frontend_url" --exclude "frontend_path" --exclude "frontend_protocol" --exclude "SynthoLicense" --exclude-regexp "core.image.*" --exclude-regexp "backend.image.*" --exclude-regexp "backend.user.*" --exclude-regexp "frontend.image.*" --exclude-regexp "redis.image.*" --exclude-regexp "db.image.*" --exclude "db.storageClassName" --exclude "db.pvLabelKey" --exclude "redis.storageClassName" --exclude "redis.pvLabelKey" --exclude "frontend.ingress.className" --exclude "frontend.ingress.hosts.0.host" --exclude "frontend.ingress.hosts.0.host" --exclude "frontend.ingress.tls.enabled" --exclude "frontend.ingress.tls.conf.0.hosts.0" --exclude "imagePullSecrets" --exclude "frontend.busyboxImage" --exclude-regexp "backend.env.*"'
           - dir: 'helm/ray/chart'
-            dyff_args: '--exclude-regexp "ray-cluster.head.resources.*" --exclude-regexp "storage.*" --exclude-regexp "kuberay-operator.image.*" --exclude-regexp "kuberay-operator.imagePullSecrets.*" --exclude-regexp "ray-cluster.image.*" --exclude-regexp "ray-cluster.common.containerEnv.*" --exclude "ray-cluster.head.initContainer.image" --exclude "ray-cluster.worker.initContainerImage"'
+            dyff_args: '--exclude-regexp "ray-cluster.head.resources.*" --exclude-regexp "storage.*" --exclude-regexp "kuberay-operator.image.*" --exclude-regexp "kuberay-operator.imagePullSecrets.*" --exclude-regexp "ray-cluster.image.*" --exclude "SynthoLicense" --exclude "ray-cluster.head.initContainer.image" --exclude "ray-cluster.worker.initContainerImage"'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/helm/ray/chart/templates/ray-secret.yaml
+++ b/helm/ray/chart/templates/ray-secret.yaml
@@ -1,0 +1,12 @@
+
+{{- if empty .Values.manualSecretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "ray-secret"
+  annotations:
+    "helm.sh/resource-policy": "keep"
+type: Opaque
+stringData:
+  license_key: {{ .Values.SynthoLicense }}
+{{- end }}

--- a/helm/ray/chart/templates/ray-secret.yaml
+++ b/helm/ray/chart/templates/ray-secret.yaml
@@ -1,4 +1,3 @@
-
 {{- if empty .Values.manualSecretName }}
 apiVersion: v1
 kind: Secret

--- a/helm/ray/chart/values.yaml
+++ b/helm/ray/chart/values.yaml
@@ -1,3 +1,9 @@
+SynthoLicense: <license-key>
+
+# Manual secret name in case secret needs to be overriden with manual one
+# Change ray-cluster.common.containerEnv as well with the correct secret name
+# manualSecretName: <secret-name>
+
 kuberay-operator:
   image:
     repository: syntho.azurecr.io/kuberay-operator
@@ -189,7 +195,10 @@ ray-cluster:
     # Include Syntho License key here
     containerEnv:
     - name: LICENSE_KEY_SIGNED
-      value: ""
+      valueFrom:
+        secretKeyRef:
+          name: ray-secret
+          key: license_key
   head:
     # rayVersion determines the autoscaler's image version.
     # It should match the Ray version in the image of the containers.

--- a/helm/ray/chart/values.yaml.tpl
+++ b/helm/ray/chart/values.yaml.tpl
@@ -1,3 +1,5 @@
+SynthoLicense: "{{ LICENSE_KEY }}"
+
 kuberay-operator:
   image:
     repository: {{ RAY_OPERATOR_IMG_REPO }}
@@ -188,7 +190,10 @@ ray-cluster:
     # Include Syntho License key here
     containerEnv:
     - name: LICENSE_KEY_SIGNED
-      value: "{{ LICENSE_KEY }}"
+      valueFrom:
+        secretKeyRef:
+          name: ray-secret
+          key: license_key
   head:
     # rayVersion determines the autoscaler's image version.
     # It should match the Ray version in the image of the containers.

--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.secret_key
             - name: DJANGO_PRODUCTION
               value: "True"
@@ -45,7 +45,7 @@ spec:
             - name: USER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.user.password
             - name: USER_NAME
               value: {{quote .Values.backend.user.username | default "admin" }}
@@ -62,7 +62,7 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.db.password
             - name: DATA_ACCESS
               value: {{.Values.backend.data_access | default "true" | quote }}
@@ -174,7 +174,7 @@ spec:
           - name: SECRET_KEY
             valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.secret_key
           - name: DJANGO_PRODUCTION
             value: "True"
@@ -187,7 +187,7 @@ spec:
           - name: USER_PASSWORD
             valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.user.password
           - name: USER_NAME
             value: {{quote .Values.backend.user.username | default "admin" }}
@@ -204,7 +204,7 @@ spec:
           - name: DB_PASSWORD
             valueFrom:
                 secretKeyRef:
-                  name: backend-secret
+                  name: {{ .Values.backend.manualSecretName | default "backend-secret" }}
                   key: backend.db.password
         {{- if or $.Values.backend.env $.Values.backend.envSecrets }}
           {{- range $key, $value := $.Values.backend.env }}

--- a/helm/syntho-ui/templates/core/core-deployment.yaml
+++ b/helm/syntho-ui/templates/core/core-deployment.yaml
@@ -29,14 +29,14 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: core-secret
+                  name: {{ .Values.core.manualSecretName | default "core-secret" }}
                   key: core.database_url
             - name: PORT
               value: {{quote .Values.core.port }}
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: core-secret
+                  name: {{ .Values.core.manualSecretName | default "core-secret" }}
                   key: core.secret_key
             - name: WORKER_TIMEOUT
               value: "{{ .Values.core.worker_timeout | default "3000" }}"
@@ -47,7 +47,10 @@ spec:
             - name: RAY_ADDRESS
               value: {{quote .Values.core.ray_address }}
             - name: LICENSE_KEY_SIGNED
-              value: {{ .Values.SynthoLicense }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.core.manualSecretName | default "core-secret"}}
+                  key: license_key
             - name: MAX_WORKERS
               value: {{ quote .Values.core.workers }}
             - name: REDIS_HOST

--- a/helm/syntho-ui/templates/core/core-secret.yaml
+++ b/helm/syntho-ui/templates/core/core-secret.yaml
@@ -10,4 +10,5 @@ type: Opaque
 stringData:
   core.secret_key: {{ .Values.core.secret_key }}
   core.database_url: "postgresql+asyncpg://{{ .Values.core.db.username }}:{{ .Values.core.db.password }}@{{ .Values.core.db.host }}:{{ .Values.core.db.port | default "5432" }}/{{ .Values.core.db.name }}"
+  license_key: {{ .Values.SynthoLicense }}
 {{- end }}

--- a/helm/syntho-ui/templates/core/core-worker-pod.yaml
+++ b/helm/syntho-ui/templates/core/core-worker-pod.yaml
@@ -33,14 +33,14 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: core-secret
+                  name: {{ .Values.core.manualSecretName | default "core-secret" }}
                   key: core.database_url
             - name: PORT
               value: {{quote .Values.core.port }}
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: core-secret
+                  name: {{ .Values.core.manualSecretName | default "core-secret" }}
                   key: core.secret_key
             - name: WORKER_TIMEOUT
               value: "{{ .Values.core.worker_timeout | default "3000" }}"
@@ -51,7 +51,10 @@ spec:
             - name: RAY_ADDRESS
               value: {{quote .Values.core.ray_address }}
             - name: LICENSE_KEY_SIGNED
-              value: {{ .Values.SynthoLicense }}
+              valueFromn:
+                secretKeyRef:
+                  name: {{ .Values.core.manualSecretName | default "core-secret"}}
+                  key: license_key
             - name: MAX_WORKERS
               value: {{ quote .Values.core.workers }}
             - name: REDIS_HOST

--- a/helm/syntho-ui/values.yaml
+++ b/helm/syntho-ui/values.yaml
@@ -38,7 +38,7 @@ core:
   # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   podDisruptionBudget: {}
   # If uncommented, disables the secret created by the Helm template, in order to change to a secret created differentlky
-  # manualSecretName: name-of-secret
+  # manualSecretName: core-secret
 
 backend:
   replicaCount: 1
@@ -73,7 +73,7 @@ backend:
   env:
     SECURE_COOKIES: "true"
   # If uncommented, this disables the secret created by the Helm chart, and allows you to point to the values of your own secret
-  # manualSecretName: name-of-secret
+  # manualSecretName: backend-secret
 
 frontend:
   replicaCount: 1

--- a/helm/syntho-ui/values.yaml
+++ b/helm/syntho-ui/values.yaml
@@ -37,6 +37,8 @@ core:
   workers: 1
   # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   podDisruptionBudget: {}
+  # If uncommented, disables the secret created by the Helm template, in order to change to a secret created differentlky
+  # manualSecretName: name-of-secret
 
 backend:
   replicaCount: 1
@@ -70,6 +72,8 @@ backend:
   podDisruptionBudget: {}
   env:
     SECURE_COOKIES: "true"
+  # If uncommented, this disables the secret created by the Helm chart, and allows you to point to the values of your own secret
+  # manualSecretName: name-of-secret
 
 frontend:
   replicaCount: 1


### PR DESCRIPTION
- Add License key to secret in Syntho-UI Helm chart
- Fix bug that would not take the new secret name into account for the deployment templates
- Add secret for Ray, and point environment variable to it