### PR TITLE
fixed typo in valueFrom for LICENSE_KEY_SIGNED

### DIFF
--- a/helm/syntho-ui/templates/core/core-worker-pod.yaml
+++ b/helm/syntho-ui/templates/core/core-worker-pod.yaml
@@ -51,7 +51,7 @@ spec:
             - name: RAY_ADDRESS
               value: {{quote .Values.core.ray_address }}
             - name: LICENSE_KEY_SIGNED
-              valueFromn:
+              valueFrom:
                 secretKeyRef:
                   name: {{ .Values.core.manualSecretName | default "core-secret"}}
                   key: license_key


### PR DESCRIPTION
There has been a small typo in `valueFrom` for `LICENSE_KEY_SIGNED` environment variable. 